### PR TITLE
Add /info endpoint

### DIFF
--- a/packages/api-connector/src/ApiConnector.ts
+++ b/packages/api-connector/src/ApiConnector.ts
@@ -23,6 +23,7 @@ import { Event, EventBasic, EventType } from "./Schema/Event";
 import { BasicFunc, Func, FuncTargetTeam, FuncTargetType, FuncType } from "./Schema/Func";
 import { GiftType } from "./Schema/Gift";
 import { Illustrator } from "./Schema/Illustrator";
+import { Info } from "./Schema/Info";
 import { Item, ItemBackgroundType, ItemType, ItemUse } from "./Schema/Item";
 import { MasterLevelInfoMap } from "./Schema/Master";
 import { MasterMission } from "./Schema/MasterMission";
@@ -1046,6 +1047,16 @@ class ApiConnector {
         if (cacheDuration === undefined) return fetch();
 
         return this.cache.grailCostInfoMap.get(null, fetch, cacheDuration <= 0 ? null : cacheDuration);
+    }
+
+    /**
+     * The `/info` endpoint is used to check if the
+     * there were any changes to data from the set
+     * {@link Region}
+     */
+    info(): Promise<Info> {
+        const fetch = () => ApiConnector.fetch<Record<Region, Info>>(`${this.host}/info`);
+        return fetch().then((infoMap) => infoMap[this.region]);
     }
 
     private static async fetch<T>(endpoint: string): Promise<T> {

--- a/packages/api-connector/src/Schema/Info.ts
+++ b/packages/api-connector/src/Schema/Info.ts
@@ -1,0 +1,4 @@
+export interface Info {
+    hash: string;
+    timestamp: number;
+}

--- a/packages/api-connector/src/index.ts
+++ b/packages/api-connector/src/index.ts
@@ -23,6 +23,7 @@ import * as Event from "./Schema/Event";
 import * as Func from "./Schema/Func";
 import * as Gift from "./Schema/Gift";
 import { Illustrator } from "./Schema/Illustrator";
+import * as Info from "./Schema/Info";
 import * as Item from "./Schema/Item";
 import * as Master from "./Schema/Master";
 import * as MasterMission from "./Schema/MasterMission";
@@ -72,6 +73,7 @@ export {
     Gift,
     Item,
     Illustrator,
+    Info,
     Mission,
     Master,
     MasterMission,


### PR DESCRIPTION
add `/info` (https://api.atlasacademy.io/rapidoc#get-/info) endpoint to the api-connector